### PR TITLE
Fix stray semicolon in DbContext

### DIFF
--- a/src/LoyaltyProgram.Infrastructure/LoyaltyDbContext.cs
+++ b/src/LoyaltyProgram.Infrastructure/LoyaltyDbContext.cs
@@ -37,5 +37,6 @@ namespace LoyaltyProgram.Infrastructure
             modelBuilder.Entity<HistoryReward>()
             .HasOne(hr => hr.Client);
         }
-    
+
     }
+}

--- a/src/LoyaltyProgram.Infrastructure/LoyaltyDbContext.cs
+++ b/src/LoyaltyProgram.Infrastructure/LoyaltyDbContext.cs
@@ -39,4 +39,3 @@ namespace LoyaltyProgram.Infrastructure
         }
     
     }
-};


### PR DESCRIPTION
## Summary
- remove extraneous `};` at end of `LoyaltyDbContext`

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629ac2af14833294127e1073400eec