### PR TITLE
Potential fix for code scanning alert no. 2: Denial of Service from comparison of user input against expensive regex

### DIFF
--- a/src/LoyaltyProgram.Application/ClientService.cs
+++ b/src/LoyaltyProgram.Application/ClientService.cs
@@ -56,12 +56,19 @@ namespace LoyaltyProgram.Application
 
         static bool IsValidEmail(string email)
         {
-            return _emailRegex.IsMatch(email);
+            try
+            {
+                return _emailRegex.IsMatch(email);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                return false;
+            }
         }
         static string GenerateCardNumber()
         {
             var prefix = new Random().Next(1000, 9999).ToString();
-            var uniqueSuffix = Guid.NewGuid().ToString("N").Substring(6, 6);;
+            var uniqueSuffix = Guid.NewGuid().ToString("N").Substring(6, 6); ;
             return $"LOYALTY-{prefix}-{uniqueSuffix}";
         }
     }

--- a/src/LoyaltyProgram.Application/ClientService.cs
+++ b/src/LoyaltyProgram.Application/ClientService.cs
@@ -7,6 +7,11 @@ namespace LoyaltyProgram.Application
 {
     public class ClientService
     {
+        private static readonly Regex _emailRegex = new Regex(
+            @"^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant,
+            TimeSpan.FromMilliseconds(500));
+
         private readonly LoyaltyDbContext _context;
         public ClientService(LoyaltyDbContext context)
         {
@@ -51,8 +56,7 @@ namespace LoyaltyProgram.Application
 
         static bool IsValidEmail(string email)
         {
-            var regex = new Regex(@"^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$");
-            return regex.IsMatch(email) ? true : false;
+            return _emailRegex.IsMatch(email);
         }
         static string GenerateCardNumber()
         {


### PR DESCRIPTION
Potential fix for [https://github.com/delitamakanda/LoyaltyProgram/security/code-scanning/2](https://github.com/delitamakanda/LoyaltyProgram/security/code-scanning/2)

In general, to fix ReDoS issues you either (a) simplify or restructure the regex to avoid backtracking-heavy constructs, or (b) enforce a timeout on regex evaluation so that even worst-case inputs cannot consume unbounded CPU. In .NET, the recommended mitigation when keeping a complex expression is to use the `Regex` constructor overload that accepts a `TimeSpan` timeout.

For this specific case, the least invasive fix that preserves existing behavior is to instantiate the `Regex` with a reasonable timeout and avoid re-creating it for every call. We can introduce a `static readonly` compiled `Regex` field in `ClientService` using the current pattern, `RegexOptions.Compiled | RegexOptions.CultureInvariant`, and a small timeout (for example, 500 ms). Then `IsValidEmail` will use this pre-created instance’s `IsMatch` rather than new-ing a `Regex` each time. This both addresses the DoS concern (because the engine will abort if evaluation exceeds the timeout) and improves performance.

Concretely:
- In `src/LoyaltyProgram.Application/ClientService.cs`, add a private static readonly `Regex` field, e.g. `_emailRegex`, initialized with the existing pattern and a timeout via the constructor overload that takes `RegexOptions` and `TimeSpan`.
- Update `IsValidEmail` to use `_emailRegex.IsMatch(email)` directly instead of instantiating a new `Regex`.
- Keep the method signature and return semantics unchanged so external behavior remains the same.

No changes are required in `ClientsController.cs` for this specific issue.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
